### PR TITLE
Change Artwork Comparison Logic

### DIFF
--- a/app/src/main/java/com/joerock/artthief/viewmodels/ArtworksViewModel.kt
+++ b/app/src/main/java/com/joerock/artthief/viewmodels/ArtworksViewModel.kt
@@ -58,10 +58,11 @@ class ArtworksViewModel(application: Application) : AndroidViewModel(application
     val artworkListByArtist: List<ArtThiefArtwork>
         get() = _artworkListByArtist
 
-    val artworkSectionCompareOrdering = mutableListOf<ArtThiefArtwork>()
-    val artworkSectionCompareMapping = mutableMapOf<Int, MutableList<Int>>()
-    var artworkSectionCompletedComparisonsCounter = 0
-    var artworkSectionCompareTotalNumComparisonsForCompletion = 0
+    var artworkSectionCompareOrdering = mutableListOf<ArtThiefArtwork>()
+    var artworksToCompare: MutableList<ArtThiefArtwork> = mutableListOf()
+    var preferenceGraph: MutableMap<Int, MutableSet<Int>> = mutableMapOf() // Adjacency list
+    var currentWinningArtwork: ArtThiefArtwork? = null
+    var isComparisonFinalized: Boolean = false
 
     private lateinit var _artworkSelectedGrid: ArtThiefArtwork
     val artworkSelectedGrid: ArtThiefArtwork


### PR DESCRIPTION
## Changes Made

- Use DAG (directed acyclic graph) and topological sort
- Sort calculates the in-degree for each artwork & processes those with no incoming edges first
- Miscellaneous code improvements to CompareFragment

## Time Complexity Improvement

sorting is now O(n) time complexity with new sorting implementation instead of O(n^2)

## Testing

manual testing with artwork list inputs of lengths from 2 to 10